### PR TITLE
fix setting rate limit info on Imgur instance after request

### DIFF
--- a/pyimgur/__init__.py
+++ b/pyimgur/__init__.py
@@ -676,11 +676,7 @@ class Imgur:
         self.client_id = client_id
         self.client_secret = client_secret
         self.DEFAULT_LIMIT = 100
-        self.ratelimit_clientlimit = None
-        self.ratelimit_clientremaining = None
-        self.ratelimit_userlimit = None
-        self.ratelimit_userremaining = None
-        self.ratelimit_userreset = None
+        self.ratelimit = None
         self.refresh_token = refresh_token
         self.verify = verify
         self.mashape_key = mashape_key
@@ -743,8 +739,7 @@ class Imgur:
         # Note: When the cache is implemented, it's important that the
         # ratelimit info doesn't get updated with the ratelimit info in the
         # cache since that's likely incorrect.
-        for key, value in ratelimit_info.items():
-            setattr(self, key[2:].replace('-', '_'), value)
+        self.ratelimit = ratelimit_info
         return content
 
     def authorization_url(self, response, state=""):

--- a/pyimgur/request.py
+++ b/pyimgur/request.py
@@ -101,5 +101,6 @@ def send_request(url, params=None, method='GET', data_field='data',
             pass
         resp.raise_for_status()
     ratelimit_info = dict((k, int(v)) for (k, v) in resp.headers.items()
-                          if k.startswith('x-ratelimit'))
+                          if k.upper().startswith('X-POST-RATE-LIMIT-')
+                          or k.upper().startswith('X-RATELIMIT-'))
     return content, ratelimit_info


### PR DESCRIPTION
also changes this so that it's a dictionary instead, which is easier to
handle (e.g. should the response header keys change on imgur API side)